### PR TITLE
Refactor rank handling to use single variable

### DIFF
--- a/startup.txt
+++ b/startup.txt
@@ -173,13 +173,9 @@
 *create Commoner false
 
 *comment Lupine section
-*create Alpha false
-*create Beta false
-*create Omega false
+*comment Lupine ranks handled via the `rank` string
 
-*comment Forsaken section
-*create Elite false
-*create Hybrid false
+*comment Forsaken ranks handled via the `rank` string
 
 
 *comment relationship menu

--- a/status.txt
+++ b/status.txt
@@ -11,25 +11,16 @@
         *return
     
 *if (alignment = "lupine")
-    *if (Alpha)
-        *set faction_stat "Alpha"
-        *return
-    *elseif (Beta)
-        *set faction_stat "Beta"
-        *return
-    *elseif (Omega)
-        *set faction_stat "Omega"
+    *if (rank != "rank")
+        *set faction_stat rank
         *return
     *else
         *set faction_stat "Human"
         *return
 
 *if (alignment = "forsaken")
-    *if (Elite)
-        *set faction_stat "Elite"
-        *return
-    *elseif (Hybrid)
-        *set faction_stat "hybrid"
+    *if (rank != "rank")
+        *set faction_stat rank
         *return
     *else
         *set faction_stat "Human"


### PR DESCRIPTION
## Summary
- use `rank` string for Lupine and Forsaken factions
- drop obsolete boolean rank flags

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fb49fda3c8321ac0d4fbbaae0c108