### PR TITLE
Normalize line endings & mark binaries

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,23 @@
+# Text files - always LF to avoid Windows CRLF fights
+*.txt          text eol=lf
+*.patch        text eol=lf
+*.md           text eol=lf
+*.json         text eol=lf
+*.js           text eol=lf
+*.css          text eol=lf
+*.html         text eol=lf
+
+# Windows-specific scripts that need CRLF
+*.bat          text eol=crlf
+
+# Images / binary assets - no merge, no diff
+*.png          binary -merge
+*.jpg          binary -merge
+*.jpeg         binary -merge
+*.ogg          binary -merge
+
+# Optional: treat .choice as plain text if we add custom files
+*.choice       text diff=default
+
+# GitHub linguist - ignore asset folder in language breakdown
+Assets/*       linguist-vendored

--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ -f ~/.huskyrc ]; then
+  . ~/.huskyrc
+fi
+
+npm_lifecycle_event=husky
+
+exit 0

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+git diff --cached --name-only -- '*.txt' | xargs dos2unix -q


### PR DESCRIPTION
## Summary
- add new .gitattributes file to normalize text files and flag binaries
- set up optional Husky pre-commit hook to convert staged .txt files to LF

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a36ae56c4832197c2bced1c78029e