### PR TITLE
Act 2 common hub + hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-git diff --cached --name-only -- '*.txt' | xargs dos2unix -q
+git diff --cached --name-only -- '*.txt' '*.md' '*.patch' | xargs dos2unix -q

--- a/mission_board.txt
+++ b/mission_board.txt
@@ -1,0 +1,2 @@
+The mission board brims with requests from across Veilfall. (Stub)
+*finish

--- a/scenes/act2_common_hub.txt
+++ b/scenes/act2_common_hub.txt
@@ -1,0 +1,24 @@
+*comment Act 2 common hub
+*set act 2
+*set chapter 1
+The vaulted chamber of Greyhaven's High Council stands silent as you enter, a sanctum where the fates of nations are whispered into being. Ancient banners hang from stone pillars, their faded colors telling tales of wars long settled. At the center, a circular table gleams under the glow of enchanted braziers, every seat occupied by figures cloaked in authority. The air hums with restrained power, a tension that crawls across your skin.
+
+Today the council convenes to decide the course of the coming conflict. Representatives from every faction have gathered: stoic Lupine envoys, imposing Varkyr nobles, and the mortal advisers who balance the scales. They watch your approach with measured interest—your actions have earned a reputation that carries weight in these halls. When the chamber doors close, murmurs hush, and all eyes fix upon you.
+
+The Chancellor rises, voice echoing off the vaulted ceiling. "Veilfall stands at the brink," he declares. "Your alliances will shape where we march next."
+
+*if (lupine_relation > varkyrs_relation)
+    The Lupine envoys bow their heads in approval, acknowledging your loyalty to their cause.
+    *set war_with_varkyrs true
+    *set war_with_lupine false
+*elseif (varkyrs_relation > lupine_relation)
+    The Varkyr nobles flash razor smiles, sensing your favor rests with them.
+    *set war_with_lupine true
+    *set war_with_varkyrs false
+*else
+    The council notes your balanced stance, awaiting a decisive push from you before taking sides.
+    *set war_with_lupine false
+    *set war_with_varkyrs false
+
+With the council's decree ringing in your ears, you are dismissed to prepare for what lies ahead.
+*finish

--- a/startup.txt
+++ b/startup.txt
@@ -8,6 +8,8 @@
     act1_varkyr
     act1_forsaken_ng+
     hub_city
+    act2_common_hub
+    mission_board
     lupine_abilities
     NewGame_plus
     Ending_Scenarios
@@ -36,6 +38,8 @@
 *create human_relation 50
 *create AssassinGuild_relation 50
 *create Night_Council_relation 0
+*create war_with_lupine false
+*create war_with_varkyrs false
 
 *comment Variables for tracking player’s bloodline, lupine rank, and age
 


### PR DESCRIPTION
## Summary
- add Act 2 hub cut scene with war-path logic
- wire up mission board stub and update scene list
- track faction war flags in startup
- expand pre-commit hook to normalize more files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a4788f7c883219fbc1e49af6cf5fc