### PR TITLE
fix case match in stats screen

### DIFF
--- a/choicescript_stats.txt
+++ b/choicescript_stats.txt
@@ -32,8 +32,8 @@
   opposed_pair forsaken_relation Forsaken
 
 *comment ---------- SPECIAL RESOURCES ----------
-*if (artifact != "")
-  Artifact Acquired: ${artifact}
+*if (artifact)
+  Artifact Acquired
 *if (blood_slots > 0)
   You carry ${blood_slots} unique blood essences.
 

--- a/startup.txt
+++ b/startup.txt
@@ -18,7 +18,7 @@
     status
 *comment CoGDemos automatically saves your progress; smPlugin is not supported.
 *comment General Section
-*create Control 100
+*create control 100
 *create Race ""
 *create alignment ""
 *create rank ""


### PR DESCRIPTION
## Summary
- make `control` variable lower-case
- show artifact as boolean in stats

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f007c7a8c8321ac2e90cfe2193d15